### PR TITLE
Add Missing `b:undo_ftplugin` to ftplugins

### DIFF
--- a/ftplugin/eruby.vim
+++ b/ftplugin/eruby.vim
@@ -7,7 +7,10 @@ if get(b:, "did_ftplugin")
   finish
 endif
 
+let s:undo_ftplugin = ""
+
 setlocal suffixesadd=.erb
+let b:undo_ftplugins = "setl suffixesadd<"
 
 " Determine the sub-filetype based on the file extension of the file
 " being opened.
@@ -45,6 +48,8 @@ else
   setlocal shiftwidth=2
   setlocal commentstring=<%#\ %s\ %>
   setlocal indentkeys==end,=else,=elsif
+
+  let b:undo_ftplugin .= " setl shiftwidth< commentstring< indentkeys<"
 endif
 
 let b:did_ftplugin = 1

--- a/ftplugin/rbs.vim
+++ b/ftplugin/rbs.vim
@@ -7,8 +7,6 @@ if get(b:, 'did_ftplugin')
   finish
 endif
 
-let b:did_ftplugin = 1
-
 setlocal shiftwidth=2
 setlocal comments=:#
 setlocal commentstring=#\ %s
@@ -21,3 +19,7 @@ endif
 " matchit.vim
 let b:match_words = '\<\%(class\|module\|interface\)\>:\<end\>'
 let b:match_skip = 's:^rbs\%(String\|Symbol\|Comment\)$'
+
+let b:undo_ftplugin = "setl shiftwidth< comments< commentstring< suffixesadd<"
+
+let b:did_ftplugin = 1

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -7,8 +7,6 @@ if get(b:, 'did_ftplugin')
   finish
 endif
 
-let b:did_ftplugin = 1
-
 setlocal shiftwidth=2
 setlocal comments=:#
 setlocal commentstring=#\ %s
@@ -22,3 +20,7 @@ endif
 " matchit.vim
 let b:match_words = g:ruby#ftplugin#match_words
 let b:match_skip = 's:^ruby\%(String\|Symbol\|Regex\|Comment\|PostfixKeyword\|MethodDefinition\|VariableOrMethod\)$'
+
+let b:undo_ftplugin = "setl shiftwidth< comments< commentstring< suffixesadd<"
+
+let b:did_ftplugin = 1


### PR DESCRIPTION
While the documentation for `b:undo_ftplugin` states that every ftplugin
SHOULD implement `b:undo_ftplugin` to undo any ftplugin's settings,
other plugins (like vim-rails) fail if this setting is NOT defined.

Therefore, attempt to create "sensible" undo logic based on the local
settings that were changed within each ftplugin.

https://stackoverflow.com/a/11426920/434038