### PR TITLE
Switch rubyTodo from Keyword to Syntax Matching

### DIFF
--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -28,7 +28,7 @@ else
 endif
 
 syn region rubyComment start=/\%#=1^=begin\>.*/ end=/\%#=1^=end\>.*/ contains=rubyTodo
-syn keyword rubyTodo BUG DEPRECATED FIXME NOTE WARNING OPTIMIZE TODO XXX TBD contained
+syn match rubyTodo /\<\(BUG\|DEPRECATED\|FIXME\|NOTE\|WARNING\|OPTIMIZE\|TODO\|XXX\|TBD\)/ contained
 
 syn match rubyShebang /\%#=1\%^#!.*/
 


### PR DESCRIPTION
Given that `syntax iskeyword` is defined (which includes `:`) using
`syntax keyword` for the TODO-style comment markers causes the syntax
highlighting to fail if *anything* follows the keyword.

For example:

```
  # TODO: This needs to be fixed....
```

would not highlight `TODO` as it was followed by a colon.  (If the colon
was removed, `TODO` is correctly highlighted.)

Switching to regexp matching lets the highlighter work regardless of
whether there is a colon or a space following the comment-marker.

A zero-width assertion is used to restrict matches to beginning of
words.  Such that `AFIXME` will not match but `FIXMEPLEASE` does.