### PR TITLE
Fix E108: No such variable: "b:match_words" when filetype is recognized as `eruby.yaml`

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -22,5 +22,5 @@ if get(g:, "loaded_matchit")
   let b:match_words = '\<\%(def\|class\|module\|if\|unless\|case\|while\|until\|for\|begin\|do\)\:\@!\>:\<\%(else\|elsif\|when\|in\|rescue\|ensure\|break\|next\|yield\|return\|raise\|redo\|retry\)\:\@!\>:\<end\:\@!\>'
   let b:match_skip = 'S:^ruby\%(Keyword\|Define\)$'
 
-  let b:undo_ftplugin ..= " | unlet b:match_words b:match_skip"
+  let b:undo_ftplugin ..= " | unlet! b:match_words b:match_skip"
 endif


### PR DESCRIPTION
Hi,

I'm using this plugin with vim-rails in Rails project, I can open `config/database.yml` without issue, but I got error `E108: No such variable: "b:match_words"` when reloading the file.

<img width="1512" alt="image" src="https://github.com/jlcrochet/vim-ruby/assets/438791/ce495e07-2834-49bc-80a4-6c74fd64dfde">


I find that `vim-rails` set filetype to `eruby.yaml` , and the error happens when it run `b:undo_ftplugin`, I changed `b:undo_ftplugin` to use `unlet!` to silent error on non-existent `b:match_words` which is removed in previous undo commands.

Here is `b:undo_ftplugin` for reference

```
:echo b:undo_ftplugin
setl cms<  | unlet! b:browsefilter b:match_words | setlocal shiftwidth< comments< commentstring< suffixesadd< | unlet b:match_words b:match_skip|unlet!
 b:match_midmap|sil! exe 'nunmap <buffer> gf'|sil! exe 'nunmap <buffer> <C-W>f'|sil! exe 'nunmap <buffer> <C-W><C-F>'|sil! exe 'nunmap <buffer> <C-W>gf
'|sil! exe 'cunmap <buffer> <C-R><C-F>'|setl com< cms< et< fo< sw< sts< | unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_
comment b:did_caw_ftplugin
```

Please help to check and merge it if you find that it does make senses, thanks.