### PR TITLE
Add exists check for b:eruby_subtype

### DIFF
--- a/syntax/eruby.vim
+++ b/syntax/eruby.vim
@@ -7,7 +7,7 @@ if exists('b:current_syntax')
   finish
 endif
 
-if b:eruby_subtype !=# ''
+if exists('b:eruby_subtype') && b:eruby_subtype !=# ''
   call ruby#subtype#source_syntax(b:eruby_subtype)
 endif
 


### PR DESCRIPTION
Hi @jlcrochet 

For the context, I'm using this syntax plugin with https://github.com/tpope/vim-markdown with the following fenced languages setting

```vim
let g:markdown_fenced_languages = ['erb=eruby', 'ruby']
```

With this setting, whenever I edit markdown file, it triggers sourcing eruby syntax and I got this error

<img width="755" alt="image" src="https://github.com/user-attachments/assets/a19c7cfd-87ec-4ec0-a4c8-4b2d25afa47c">


I figured out that just need to add the check `exists('b:eruby_subtype')` to `syntax/eruby.vim` should fix the problem. Please help to review and merge this PR if you feel it does make senses.
